### PR TITLE
InputText: fixing focus & setting custom errors

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -2,3 +2,5 @@ import '@storybook/addon-actions/register'
 import '@storybook/addon-knobs/register'
 import '@storybook/addon-links/register'
 import '@storybook/addon-viewport/register'
+
+import '@dump247/storybook-state/register'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1271,6 +1271,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "@dump247/storybook-state": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@dump247/storybook-state/-/storybook-state-1.6.1.tgz",
+      "integrity": "sha512-auc01jSinxeV1EF1cJvVNKERxHwqkZEF3GWnz12S8EIcgAWE5eQM4Onp/zzSgFEhG2UgOHf0LLPdSMKs6xNdWQ==",
+      "dev": true,
+      "requires": {
+        "react": "^16.6.0",
+        "react-json-view": "^1.13.3"
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.27.tgz",
@@ -6299,6 +6309,12 @@
         }
       }
     },
+    "base16": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+      "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -9694,6 +9710,15 @@
         "bser": "^2.0.0"
       }
     },
+    "fbemitter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
+      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.4"
+      }
+    },
     "fbjs": {
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
@@ -9970,6 +9995,16 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "flux": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
+      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
+      "dev": true,
+      "requires": {
+        "fbemitter": "^2.0.0",
+        "fbjs": "^0.8.0"
       }
     },
     "fn-name": {
@@ -13954,10 +13989,22 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.curry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha1-h79AKSuM+D5OjOGjrkIJ4gBxZ1o=",
       "dev": true
     },
     "lodash.get": {
@@ -16752,6 +16799,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pure-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
+      "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4=",
+      "dev": true
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -16892,6 +16945,18 @@
         "fbjs": "^0.8.4",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.0"
+      }
+    },
+    "react-base16-styling": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
+      "integrity": "sha1-7yFW1mz0E5aVyKFniGy2nqZgeSw=",
+      "dev": true,
+      "requires": {
+        "base16": "^1.0.0",
+        "lodash.curry": "^4.0.1",
+        "lodash.flow": "^3.3.0",
+        "pure-color": "^1.2.0"
       }
     },
     "react-clientside-effect": {
@@ -17373,6 +17438,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
       "dev": true
+    },
+    "react-json-view": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",
+      "integrity": "sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==",
+      "dev": true,
+      "requires": {
+        "flux": "^3.1.3",
+        "react-base16-styling": "^0.6.0",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-textarea-autosize": "^6.1.0"
+      },
+      "dependencies": {
+        "react-textarea-autosize": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-6.1.0.tgz",
+          "integrity": "sha512-F6bI1dgib6fSvG8so1HuArPUv+iVEfPliuLWusLF+gAKz0FbB4jLrWUrTAeq1afnPT2c9toEZYUdz/y1uKMy4A==",
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.0"
+          }
+        }
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
+    "@dump247/storybook-state": "^1.6.1",
     "@storybook/addon-actions": "^5.3.2",
     "@storybook/addon-info": "^5.3.2",
     "@storybook/addon-knobs": "^5.3.2",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.0.18
+
+- Added [Storybook State](https://github.com/dump247/storybook-state/) addon for showing changes in state within one component story
+
+## InputText
+
+- Improved `error` prop handling (allow error to be cleared & revalidated)
+- Updated deprecated component lifecycle method, from `UNSAFE_componentWillReceiveProps` to `componentDidUpdate`
+- Added support for HTML5 `autoFocus` (while retaining `focused` for now)
+- Removed focus from being handled internally
+- Added stories for focus and custom error states
+
 # 0.0.17
 
 ## TextArea

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Shared React UI library that implements the Healthwise design language.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",

--- a/packages/core/src/InputText/InputText.stories.js
+++ b/packages/core/src/InputText/InputText.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import { withState } from '@dump247/storybook-state'
 
 import InputText from './index'
 
@@ -93,6 +94,24 @@ storiesOf('core|Form Controls/Input Text', module)
     }
   )
   .add(
+    'with focus',
+    () => (
+      <div>
+        <div style={styles.container}>
+          <InputText
+            autoFocus
+            label="Label"
+            placeholder="Placeholder text"
+            onChange={action('onChange')}
+          />
+        </div>
+      </div>
+    ),
+    {
+      info: `Demonstrates InputText with a label`,
+    }
+  )
+  .add(
     'disabled',
     () => (
       <div>
@@ -145,6 +164,23 @@ storiesOf('core|Form Controls/Input Text', module)
     {
       info: `Demonstrates an InputText component with error messages`,
     }
+  )
+  .add(
+    'with custom error',
+    withState({ error: 'This needs a click!' })(({ store }) => (
+      <div style={styles.container}>
+        <p>Click the input to toggle the custom error.</p>
+        <InputText
+          label="Label"
+          placeholder="Placeholder text"
+          error={store.state.error}
+          onClick={() => {
+            const error = store.state.error ? '' : store.initialState.error
+            store.set({ error })
+          }}
+        />
+      </div>
+    ))
   )
   .add(
     'with all types',


### PR DESCRIPTION
1. Removed focus state from being handled internally, as this should be handled as a prop.
2. Fixed `focused` prop to actually trigger the `autoFocus` HTML5 property.
3. Added `autoFocus` property, to overlap with everything `focused` is doing.  (As a breaking change, I'd like to migrate away from `focused` altogether, since the other property is actually part of the spec.)
4. Improved custom error handling, so that custom errors can now be reset.
5. Updated deprecated component lifecycle method, from `UNSAFE_componentWillReceiveProps` to `componentDidUpdate`
6. Added stories for focus and custom error states

Also added a [Storybook addon](https://github.com/dump247/storybook-state/) for demonstrating changing state within a story (which is an addon officially recommended by Storybook).