### PR TITLE
revert flex, fix missing image size, bump version

### DIFF
--- a/packages/content/package-lock.json
+++ b/packages/content/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/content",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2093,12 +2093,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2113,17 +2115,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2240,7 +2245,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2252,6 +2258,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2266,6 +2273,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2273,12 +2281,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2297,6 +2307,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2386,7 +2397,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2398,6 +2410,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2519,6 +2532,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/content",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Shared React UI library to use with Healthwise content.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",

--- a/packages/content/src/MediaGallery/index.js
+++ b/packages/content/src/MediaGallery/index.js
@@ -86,9 +86,7 @@ const SectionGallery = styled.section`
 `
 
 const UlList = styled.ul`
-  display: flex;
-  flex-direction: row;
-  margin: 0 0 18px 0;
+  margin: 0;
   padding: 0;
 
   & li {
@@ -128,7 +126,7 @@ const ActiveThumbnailButton = styled.button`
   padding: 0;
   width: 84px;
   height: 56px;
-  border: 1px solid #abb2c1;
+  border: 1px solid #017acd;
   cursor: pointer;
 
   &:focus,
@@ -137,7 +135,11 @@ const ActiveThumbnailButton = styled.button`
     outline: 2px solid #000;
   }
 
-  border: 1px solid #017acd;
+  & img {
+    width: 84px;
+    height: 56px;
+  }
+
 `
 
 class MediaGallery extends Component {


### PR DESCRIPTION
turns out the image size was what was bloating the row height. This is an area where work had been done when the last attempt was made to bring this repo into the esdps - I'm guessing this was simply missed when ported to styled-components.

This fix reverts the flex attempt and solves the image size issue by making them match the container, which is a `button` element. 