### PR TITLE
Jsaraceno/media service video a11y

### DIFF
--- a/packages/content/package-lock.json
+++ b/packages/content/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/content",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/content",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Shared React UI library to use with Healthwise content.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",

--- a/packages/content/src/MediaServiceVideo/index.js
+++ b/packages/content/src/MediaServiceVideo/index.js
@@ -133,7 +133,7 @@ class MediaServiceVideo extends Component {
           ref={el => {
             this.videoElement = el
           }}
-          title="Video"
+          title={`Video ${title}`}
           className={`hw-slide-video`}
           src={videoUrl}
           frameBorder="0"

--- a/packages/content/src/MediaServiceVideo/index.js
+++ b/packages/content/src/MediaServiceVideo/index.js
@@ -107,12 +107,14 @@ class MediaServiceVideo extends Component {
     const videoUrl = `${mediaServiceUrl}/html/${mediaToken}/${videoParts.id}/${videoParts.lang}?autostart=false&rt=${mediaToken}&hash=${mediaHash}&disclaimer=false`
     let abstract = null
     let type = null
-    let title = null
+    let titleText = null
+    let titleElement = null
 
     if (!hideAbstract) {
       const dom = this.parseHtml(`<div>${item.html}</div>`)
       abstract = <SpanAbstract>{item.abstract.consumer}</SpanAbstract>
-      title = <H3Title>{dom.querySelector('h3').firstChild.nodeValue}</H3Title>
+      titleText = dom.querySelector('h3').firstChild.nodeValue
+      titleElement = <H3Title>{dom.querySelector('h3').firstChild.nodeValue}</H3Title>
     }
 
     if (!hideType) {
@@ -126,14 +128,14 @@ class MediaServiceVideo extends Component {
         }}
       >
         {type}
-        {title}
+        {titleElement}
         {abstract}
         <Video
           as="iframe"
           ref={el => {
             this.videoElement = el
           }}
-          title={`Video ${title}`}
+          title={`Play Video ${titleText}`}
           className={`hw-slide-video`}
           src={videoUrl}
           frameBorder="0"


### PR DESCRIPTION
Apparently a screen reader looks up to the iframe's `title` attribute to determine what the media service's internal play button will announce when focussed. We obviously already had all this information but it was not being piped into the `title` attr, so it would just say "Video" along with a bunch of other chatty stuff. 

Now, it announces "Play Video <title of video>" and then the other chatty stuff.