### PR TITLE
Resolve npm publishing recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "lint": "eslint --fix .",
-    "publish": "lerna run publish",
-    "publish:dryrun": "lerna run publish:dryrun",
+    "dopublish": "lerna run dopublish",
+    "dopublish:dryrun": "lerna run dopublish:dryrun",
     "reset": "npm run clean && rimraf node_modules && npm install"
   },
   "husky": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -25,8 +25,8 @@
     "prebuild": "npm run clean",
     "postbuild": "node scripts/copyFiles.js",
     "clean": "rimraf build",
-    "publish": "npm run build && npm publish build",
-    "publish:dryrun": "npm run build && npm publish build --dry-run"
+    "dopublish": "npm run build && npm publish build",
+    "dopublish:dryrun": "npm run build && npm publish build --dry-run"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,8 @@
     "prebuild": "npm run clean",
     "postbuild": "node scripts/copyFiles.js",
     "clean": "rimraf build",
-    "publish": "npm run build && npm publish build",
-    "publish:dryrun": "npm run build && npm publish build --dry-run",
+    "dopublish": "npm run build && npm publish build",
+    "dopublish:dryrun": "npm run build && npm publish build --dry-run",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
As far as I could test/determine, having a `package.json` npm script named "**publish**" will always be recursive/problematic.  This is due to the fact that `publish` is an npm command, so naming a script the same (and using that script to try to run the command) will recurse.  And die.

I believe we will have to update our Actions in order to run this script by name.

There may be another way around this, but this was the best I could do.  I think most people probably just run `publish` directly from the command line, but I was hesitant to do that because want to make sure to publish the correct build directory, and I figured it's easier to run an existing script than remember that.  Feel free to reject/alter if you know of a better way.