### PR TITLE
Swapping `InputText` ref over to createRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.2
+
+## InputText
+- Swapped `InputText` ref over to createRef (to fix `ref` potentially being `null`)
+
 # 1.0.1
 
 ## SplitButton

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shared React UI library that implements the Healthwise design language.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",

--- a/src/InputText/index.js
+++ b/src/InputText/index.js
@@ -105,6 +105,8 @@ class InputText extends Component {
   constructor(props) {
     super(props)
 
+    this.input = React.createRef()
+
     this.fallbackError = 'Value is unexpected.'
     const validationErrors = Object.assign(
       {
@@ -171,8 +173,8 @@ class InputText extends Component {
 
     const validationErrors = this.state.validationErrors
     const fallbackError = this.fallbackError
-    const input = this.input
-    const validity = input.validity
+    const input = this.input.current
+    const validity = input && input.validity
     let isValid = !error
     let errorType = error ? 'supplied' : null
     let errorMessage = error || null
@@ -289,9 +291,7 @@ class InputText extends Component {
         )}
         <Input
           className={classNames('hw-input-text', `hw-input-text-${type}`, className)}
-          ref={el => {
-            this.input = el
-          }}
+          ref={this.input}
           type={type}
           placeholder={placeholder}
           required={required}


### PR DESCRIPTION
Addresses a problem we encountered where `this.input` wasn't always defined in the `checkValidity` function.