### PR TITLE
Jsaraceno/sol 273 tabgroup refactor

### DIFF
--- a/src/Tab/index.js
+++ b/src/Tab/index.js
@@ -94,10 +94,11 @@ class Tab extends Component {
       disabled,
       onClick,
       theme,
+      onKeyUp,
       ...otherProps
     } = this.props
 
-    const tabIndex = this.props.isActive ? null : '-1'
+    const tabIndex = this.props.onKeyUp ? (this.props.isActive ? null : '-1') : null
 
     const tabClassName = classNames('hw-tab', { 'hw-tab-is-active': isActive }, className)
 
@@ -112,6 +113,7 @@ class Tab extends Component {
         theme={theme}
         visited={visited}
         isActive={isActive}
+        onKeyUp={onKeyUp}
         disabled={disabled}
         style={{ minWidth }}
         role="tab"
@@ -133,6 +135,7 @@ Tab.propTypes = {
   minWidth: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
+  onKeyUp: PropTypes.func,
   theme: PropTypes.shape({
     colorPrimaryLight: PropTypes.string,
     colorPrimary: PropTypes.string,

--- a/src/Tab/index.js
+++ b/src/Tab/index.js
@@ -94,7 +94,7 @@ class Tab extends Component {
       disabled,
       onClick,
       theme,
-      onKeyUp, // from clonedProps. Is this an anti-pattern?
+      // onKeyUp, // from clonedProps. Is this an anti-pattern?
       ...otherProps
     } = this.props
 
@@ -105,9 +105,11 @@ class Tab extends Component {
     return (
       <Root
         className={tabClassName}
+        href={href}
         tabIndex={tabIndex}
         aria-disabled={disabled}
-        onKeyUp={onKeyUp}
+        accessKey={accessKey}
+        // onKeyUp={onKeyUp}
         onClick={onClick}
         theme={theme}
         visited={visited}
@@ -133,7 +135,7 @@ Tab.propTypes = {
   minWidth: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
-  onKeyUp: PropTypes.func,
+  // onKeyUp: PropTypes.func,
   theme: PropTypes.shape({
     colorPrimaryLight: PropTypes.string,
     colorPrimary: PropTypes.string,

--- a/src/Tab/index.js
+++ b/src/Tab/index.js
@@ -5,7 +5,8 @@ import styled, { withTheme } from 'styled-components'
 
 import { defaultTheme } from '../Theme'
 
-const Root = styled.a`
+const Root = styled.button`
+  width: 100%;
   box-sizing: border-box;
   height: 100%;
   display: flex;
@@ -91,23 +92,27 @@ class Tab extends Component {
       disabled,
       onClick,
       theme,
+      onKeyUp, // from clonedProps. Is this an anti-pattern?
       ...otherProps
     } = this.props
+
+    const tabIndex = this.props.isActive ? null : '-1'
 
     const tabClassName = classNames('hw-tab', { 'hw-tab-is-active': isActive }, className)
 
     return (
       <Root
         className={tabClassName}
-        href={href}
+        tabIndex={tabIndex}
         aria-disabled={disabled}
-        accessKey={accessKey}
+        onKeyUp={onKeyUp}
         onClick={onClick}
         theme={theme}
         visited={visited}
         isActive={isActive}
         disabled={disabled}
         style={{ minWidth }}
+        role="tab"
         {...otherProps}
       >
         <div>{children}</div>
@@ -126,6 +131,7 @@ Tab.propTypes = {
   minWidth: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
+  onKeyUp: PropTypes.func,
   theme: PropTypes.shape({
     colorPrimaryLight: PropTypes.string,
     colorPrimary: PropTypes.string,

--- a/src/Tab/index.js
+++ b/src/Tab/index.js
@@ -6,6 +6,7 @@ import styled, { withTheme } from 'styled-components'
 import { defaultTheme } from '../Theme'
 
 const Root = styled.button`
+  background-color: transparent; /* let the container set background color */
   width: 100%;
   box-sizing: border-box;
   height: 100%;
@@ -19,6 +20,7 @@ const Root = styled.button`
   font-size: 1.25em;
   text-align: center;
   text-decoration: none;
+  border: none; /* reset since buttons have borders */
   border-bottom-width: 4px;
   border-bottom-style: solid;
   border-bottom-color: ${props =>

--- a/src/Tab/index.js
+++ b/src/Tab/index.js
@@ -94,7 +94,6 @@ class Tab extends Component {
       disabled,
       onClick,
       theme,
-      // onKeyUp, // from clonedProps. Is this an anti-pattern?
       ...otherProps
     } = this.props
 
@@ -109,7 +108,6 @@ class Tab extends Component {
         tabIndex={tabIndex}
         aria-disabled={disabled}
         accessKey={accessKey}
-        // onKeyUp={onKeyUp}
         onClick={onClick}
         theme={theme}
         visited={visited}
@@ -135,7 +133,6 @@ Tab.propTypes = {
   minWidth: PropTypes.string,
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
-  // onKeyUp: PropTypes.func,
   theme: PropTypes.shape({
     colorPrimaryLight: PropTypes.string,
     colorPrimary: PropTypes.string,

--- a/src/TabGroup/TabGroup.stories.js
+++ b/src/TabGroup/TabGroup.stories.js
@@ -9,6 +9,8 @@ const onClick = event => {
   event.preventDefault()
 }
 
+const selectTab = (index, direction) => {}
+
 storiesOf('core|Components/Tab Group', module)
   .add(
     'with defaults',
@@ -215,5 +217,29 @@ storiesOf('core|Components/Tab Group', module)
     ),
     {
       info: `Demonstrates tab with 'minWidth' prop set`,
+    }
+  )
+  .add(
+    'with all statuses and tab selection handler props',
+    () => (
+      <div>
+        <TabGroup selectTab={selectTab}>
+          <Tab href="#" onClick={onClick} isActive>
+            Active
+          </Tab>
+          <Tab href="#" onClick={onClick} visited>
+            Visited
+          </Tab>
+          <Tab href="#" onClick={onClick} disabled>
+            Disabled
+          </Tab>
+          <Tab href="#" onClick={onClick}>
+            Unvisited
+          </Tab>
+        </TabGroup>
+      </div>
+    ),
+    {
+      info: `Demonstrates the various tab statuses with a tab selection handler passed in`,
     }
   )

--- a/src/TabGroup/index.js
+++ b/src/TabGroup/index.js
@@ -75,16 +75,28 @@ class TabGroup extends Component {
   render() {
     const { children, className, stretch, theme, ...otherProps } = this.props
 
+    const childrenWithProps = React.Children.map(this.props.children, (child, index) => {
+      // need to add the function to the props of each child
+      // since they were defined in the parent of the tabgroup (this element)
+      // and passed in as child(ren)
+      return React.cloneElement(child, {
+        onKeyUp: e => {
+          this.handleKeyup(e, index)
+        },
+      })
+    })
+
     return (
       <Root
+        role="tablist"
         ref={this.tabGroup}
         className={classNames('hw-tab-group', className)}
         stretch={stretch}
         theme={theme}
         {...otherProps}
       >
-        {React.Children.map(children, (tab, index) => (
-          <Container key={index} stretch={stretch} theme={theme}>
+        {React.Children.map(childrenWithProps, (tab, index) => (
+          <Container key={index} stretch={stretch} theme={theme} role="presentation">
             {tab}
           </Container>
         ))}
@@ -104,6 +116,7 @@ TabGroup.propTypes = {
     spacingXs: PropTypes.string,
     spacingL: PropTypes.string,
   }),
+  selectTab: PropTypes.func,
 }
 
 TabGroup.defaultProps = {

--- a/src/TabGroup/index.js
+++ b/src/TabGroup/index.js
@@ -50,6 +50,7 @@ class TabGroup extends Component {
   constructor() {
     super()
     this.tabGroup = React.createRef()
+    // this.handleKeyup = this.handleKeyup.bind(this)
   }
 
   componentDidMount() {
@@ -72,19 +73,44 @@ class TabGroup extends Component {
     }
   }
 
+  // previousTab(index) {
+  //   console.log("PREVIOUS TAB")
+  //   //TODO: DOUBLE CHECK FOR DISABLED PREV ELEMENT
+  //   if (index > 0) {
+  //     return this.props.selectTab(index - 1)
+  //   }
+  //   this.props.selectTab(this.props.children.length - 1)
+  // }
+
+  // nextTab(index) {
+  //   console.log("NEXT TAB")
+  //   //TODO: DOUBLE CHECK FOR DISABLED NEXT ELEMENT
+  //   if (index < this.props.children.length - 1) {
+  //     return this.props.selectTab(index + 1)
+  //   }
+  //   this.props.selectTab(0)
+  // }
+
+  // handleKeyup(e, tab) {
+  //   e.preventDefault()
+  //   if (e.which === 13) this.selectTab(tab)
+  //   else if (e.which === 37) this.previousTab(tab)
+  //   else if (e.which === 39) this.nextTab(tab)
+  // }
+
   render() {
     const { children, className, stretch, theme, ...otherProps } = this.props
 
-    const childrenWithProps = React.Children.map(this.props.children, (child, index) => {
-      // need to add the function to the props of each child
-      // since they were defined in the parent of the tabgroup (this element)
-      // and passed in as child(ren)
-      return React.cloneElement(child, {
-        onKeyUp: e => {
-          this.handleKeyup(e, index)
-        },
-      })
-    })
+    // const childrenWithProps = React.Children.map(this.props.children, (child, index) => {
+    //   // need to add the function to the props of each child
+    //   // since they were defined in the parent of the tabgroup (this element)
+    //   // and passed in as child(ren)
+    //   return React.cloneElement(child, {
+    //     onKeyUp: e => {
+    //       this.handleKeyup(e, index)
+    //     },
+    //   })
+    // })
 
     return (
       <Root
@@ -95,7 +121,7 @@ class TabGroup extends Component {
         theme={theme}
         {...otherProps}
       >
-        {React.Children.map(childrenWithProps, (tab, index) => (
+        {React.Children.map(/* childrenWithProps */ children, (tab, index) => (
           <Container key={index} stretch={stretch} theme={theme} role="presentation">
             {tab}
           </Container>
@@ -116,7 +142,7 @@ TabGroup.propTypes = {
     spacingXs: PropTypes.string,
     spacingL: PropTypes.string,
   }),
-  selectTab: PropTypes.func,
+  // selectTab: PropTypes.func,
 }
 
 TabGroup.defaultProps = {

--- a/src/TabGroup/index.js
+++ b/src/TabGroup/index.js
@@ -50,7 +50,6 @@ class TabGroup extends Component {
   constructor() {
     super()
     this.tabGroup = React.createRef()
-    // this.handleKeyup = this.handleKeyup.bind(this)
   }
 
   componentDidMount() {
@@ -73,44 +72,8 @@ class TabGroup extends Component {
     }
   }
 
-  // previousTab(index) {
-  //   console.log("PREVIOUS TAB")
-  //   //TODO: DOUBLE CHECK FOR DISABLED PREV ELEMENT
-  //   if (index > 0) {
-  //     return this.props.selectTab(index - 1)
-  //   }
-  //   this.props.selectTab(this.props.children.length - 1)
-  // }
-
-  // nextTab(index) {
-  //   console.log("NEXT TAB")
-  //   //TODO: DOUBLE CHECK FOR DISABLED NEXT ELEMENT
-  //   if (index < this.props.children.length - 1) {
-  //     return this.props.selectTab(index + 1)
-  //   }
-  //   this.props.selectTab(0)
-  // }
-
-  // handleKeyup(e, tab) {
-  //   e.preventDefault()
-  //   if (e.which === 13) this.selectTab(tab)
-  //   else if (e.which === 37) this.previousTab(tab)
-  //   else if (e.which === 39) this.nextTab(tab)
-  // }
-
   render() {
     const { children, className, stretch, theme, ...otherProps } = this.props
-
-    // const childrenWithProps = React.Children.map(this.props.children, (child, index) => {
-    //   // need to add the function to the props of each child
-    //   // since they were defined in the parent of the tabgroup (this element)
-    //   // and passed in as child(ren)
-    //   return React.cloneElement(child, {
-    //     onKeyUp: e => {
-    //       this.handleKeyup(e, index)
-    //     },
-    //   })
-    // })
 
     return (
       <Root
@@ -121,7 +84,7 @@ class TabGroup extends Component {
         theme={theme}
         {...otherProps}
       >
-        {React.Children.map(/* childrenWithProps */ children, (tab, index) => (
+        {React.Children.map(children, (tab, index) => (
           <Container key={index} stretch={stretch} theme={theme} role="presentation">
             {tab}
           </Container>
@@ -142,7 +105,6 @@ TabGroup.propTypes = {
     spacingXs: PropTypes.string,
     spacingL: PropTypes.string,
   }),
-  // selectTab: PropTypes.func,
 }
 
 TabGroup.defaultProps = {

--- a/src/TabGroup/index.js
+++ b/src/TabGroup/index.js
@@ -50,6 +50,7 @@ class TabGroup extends Component {
   constructor() {
     super()
     this.tabGroup = React.createRef()
+    this.handleKeyup = this.handleKeyup.bind(this)
   }
 
   componentDidMount() {
@@ -72,8 +73,29 @@ class TabGroup extends Component {
     }
   }
 
+  handleKeyup(e, index) {
+    e.preventDefault()
+    if (e.which === 13 || e.which === 32) this.props.selectTab(index, 'CURRENT')
+    else if (e.which === 37 || e.which === 38) this.props.selectTab(index, 'PREV')
+    else if (e.which === 39 || e.which === 40) this.props.selectTab(index, 'NEXT')
+  }
+
   render() {
-    const { children, className, stretch, theme, ...otherProps } = this.props
+    const { children, className, stretch, theme, selectTab, ...otherProps } = this.props
+
+    const childrenTabs = selectTab
+      ? React.Children.map(this.props.children, (childTab, index) => {
+          // if a tab selection function was passed as props, we need to also map the keyup function to the children
+          // to ensure that the user can navigate with the keyboard
+          // since they were defined in the parent of the tabgroup (this element)
+          // and passed in as child(ren)
+          return React.cloneElement(childTab, {
+            onKeyUp: e => {
+              this.handleKeyup(e, index)
+            },
+          })
+        })
+      : [...children]
 
     return (
       <Root
@@ -84,7 +106,7 @@ class TabGroup extends Component {
         theme={theme}
         {...otherProps}
       >
-        {React.Children.map(children, (tab, index) => (
+        {React.Children.map(childrenTabs, (tab, index) => (
           <Container key={index} stretch={stretch} theme={theme} role="presentation">
             {tab}
           </Container>
@@ -105,6 +127,7 @@ TabGroup.propTypes = {
     spacingXs: PropTypes.string,
     spacingL: PropTypes.string,
   }),
+  selectTab: PropTypes.func,
 }
 
 TabGroup.defaultProps = {


### PR DESCRIPTION
These are improvements to the a11y markup and logic that we provide in the current TabGroup. The roving Tabindex is also easily accomplished here, which will remove any Tab elements from the tab order while they are not selected. 

However, the gap now present is the action to select another tab- it may be implementation-specific - the ESDP's for instance fire off a router push when a new tab is selected, essentially navigating to a different SPA page when "activated".

This solution: 
TabGroup will be passed a TabSelect function prop from the parent (esdp in my case) that when called with some data about the selected tab can call the correct selection logic in the parent - in the ESDP case this is done via router navigation pushes. 

To avoid breaking changes, the new tabIndex behavior to only take place when the TabSelect function exists in props, to avoid breaking change. 

This seems like maybe an anti pattern but I'm not sure of a better way to continue. Please let me know if you have any guidance here.