### PR TITLE
Fixing npm publish blunder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.1.0
+# 2.1.1
+
+- Iterating version for new `npm publish`
+
+# 2.1.0 (DEPRECATED - due to `npm publish` mistake)
 
 - Brought more consistency and accessibility to disabled states (`Accordion`, `Button`, `Checkbox`, `DropDown`, `InputText`, `Radio` & `TextArea`)
 - Added `viewOnly` prop for `Checkbox`, `InputText`, `Radio` & `TextArea` components (and associated stories)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Shared React UI library that implements the Healthwise design language.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",


### PR DESCRIPTION
I accidentally `npm published` from the root, rather than from the build folder.  Whoops.