### PR TITLE
View only status tweaks

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -6,8 +6,6 @@ name: Storybook Deploy
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build-and-deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.1.2
+
+- Overriding browser default backgrounds for `viewOnly` state on `InputText` and `TextArea`
+- Added precommit testing, linting
+
 # 2.1.1
 
 - Iterating version for new `npm publish`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "2.0.2",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2154,9 +2154,9 @@
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.1.tgz",
-      "integrity": "sha512-IilcGWdN1yNgEGOrB96jbTplRh+V2Pz1EoEwsKsHfX1a/L40cUYuD71Zepa7C+ujv7kJIxnDftWeZbKNEqZjCQ==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.5.tgz",
+      "integrity": "sha512-1JJusg3iPgsZDthyWiCr3KQiGs31ikU/mSf2N2dSYEAO0GEImmVUbWf0VoSDGDFTAn5Dj4DUiR6SdIXHY7tELA==",
       "dev": true,
       "requires": {
         "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
@@ -2202,9 +2202,9 @@
           }
         },
         "@babel/types": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
+          "version": "7.12.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
+          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
           "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.4",
@@ -2429,18 +2429,32 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.1.tgz",
-      "integrity": "sha512-euCExymHCi0qB9u5fKw7rvlw7AZSjw/NaB9h7EkdTt5+yHRrXdiRTh7fkG3uBPpJg82CqLfp1LHLqWGSCrab+g==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.12.5.tgz",
+      "integrity": "sha512-jcs++VPrgyFehkMezHtezS2BpnUlR7tQFAyesJn1vGTO9aTFZrgIQrA5YydlTwxbcjMwkFY6i04flCigRRr3GA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4",
         "@babel/plugin-transform-react-display-name": "^7.12.1",
-        "@babel/plugin-transform-react-jsx": "^7.12.1",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.1",
+        "@babel/plugin-transform-react-jsx": "^7.12.5",
+        "@babel/plugin-transform-react-jsx-development": "^7.12.5",
         "@babel/plugin-transform-react-jsx-self": "^7.12.1",
         "@babel/plugin-transform-react-jsx-source": "^7.12.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+      },
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.5.tgz",
+          "integrity": "sha512-2xkcPqqrYiOQgSlM/iwto1paPijjsDbUynN13tI6bosDz/jOW3CRzYguIE8wKX32h+msbBM22Dv5fwrFkUOZjQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-builder-react-jsx": "^7.10.4",
+            "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-jsx": "^7.12.1"
+          }
+        }
       }
     },
     "@babel/preset-typescript": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run test && lint-staged"
+      "pre-commit": "lint-staged && npm run test -- --watchAll=false && npm run build"
     }
   },
   "lint-staged": {
-    "*.js": [
-      "npm run lint --",
+    "*.+(js|css|mdx)": [
+      "npm run lint",
       "git add"
     ]
   },
@@ -60,7 +60,7 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@babel/preset-react": "^7.12.1",
+    "@babel/preset-react": "^7.12.5",
     "@dump247/storybook-state": "^1.6.1",
     "@storybook/addon-actions": "^5.3.21",
     "@storybook/addon-docs": "^5.3.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Shared React UI library that implements the Healthwise design language.",
   "main": "index.js",
   "unpkg": "healthwise-ui.min.js",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "dopublish:dryrun": "npm run build && npm publish build --dry-run",
     "reset": "npm run clean && rimraf node_modules && npm install"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run test && lint-staged"
+    }
+  },
   "lint-staged": {
     "*.js": [
       "npm run lint --",

--- a/src/Accordion/Accordion.js
+++ b/src/Accordion/Accordion.js
@@ -34,7 +34,7 @@ const ExpansionPanel = withStyles(theme => ({
   },
   disabled: {
     opacity: 0.6,
-    cursor: 'not-allowed'
+    cursor: 'not-allowed',
   },
 }))(MuiExpansionPanel)
 

--- a/src/InputText/index.js
+++ b/src/InputText/index.js
@@ -68,7 +68,11 @@ const Input = styled.input`
       ? `1px solid ${props.theme.colorError}`
       : `1px solid ${props.theme.colorTextPrimary}`};
   background: ${props =>
-    props.disabled ? '#eee' : props.underlined ? 'none' : props.theme.colorBackgroundLight};
+    props.disabled
+      ? '#eee'
+      : props.underlined || props.viewOnly
+      ? 'none'
+      : props.theme.colorBackgroundLight};
   transition: border ease 0.2s;
   box-shadow: none;
 

--- a/src/TextArea/index.js
+++ b/src/TextArea/index.js
@@ -44,6 +44,7 @@ const TextArea = styled.textarea`
   line-height: 1.5em;
   resize: vertical;
   color: var(--color-text-primary, #424242);
+  ${props => (props.viewOnly ? 'background: none;' : '')}
 
   &:disabled {
     cursor: not-allowed;

--- a/src/TextArea/index.js
+++ b/src/TextArea/index.js
@@ -52,7 +52,7 @@ const TextArea = styled.textarea`
   }
 
   &:focus {
-    outline: ${props => props.theme.focusIndicator};
+    outline: ${props => (props.underlined || props.viewOnly ? 'none' : props.theme.focusIndicator)};
     outline-offset: ${props => props.theme.focusIndicatorOffset};
   }
 `
@@ -320,6 +320,7 @@ class Textarea extends React.Component {
           value={value}
           disabled={disabled}
           viewOnly={viewOnly}
+          readOnly={viewOnly}
           error={error || !isValid}
           required={required}
           aria-required={required}


### PR DESCRIPTION
1. Removed default browser CSS background for `viewOnly` states on `InputText` and `TextArea`
2. Fixed overly aggressive Github Action Storybook build (so it's on master merge, not just on creation of PR)
3. Added in some commit-based linting, testing, building