### PR TITLE
Fix icon array styling in IE11

### DIFF
--- a/src/IconArray/index.js
+++ b/src/IconArray/index.js
@@ -39,8 +39,10 @@ const IconSpan = styled.span`
 
   /* Thank you, IE, and the horse you rode in on */
   @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-    padding-bottom: 160%;
-    height: 1px;
+    padding-bottom: 5%;    
+    width: 10%;
+    height: auto;
+    max-height: 48.27px;
     overflow: visible;
     display: block;
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10688803/115882082-683f0e80-a41a-11eb-8b0e-795e19a8a417.png)
