### PR TITLE
Fixing modal on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.2
+
+- Removing maxWidth prop from `Modal`
+- Removing unused fullScreen prop from `Modal`
+- Fixing onClose event for `Modal`
+- Removing onClose stories for `Modal` since they are overidden by ModalStoryWrapper
+
 # 3.2.1
 
 - Adding initial z-index to top level `Modal` container

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@healthwise-ui/core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Shared React UI library that implements the Healthwise design language.",
   "main": "build/index.cjs.js",
   "module": "build/index.esm.js",

--- a/src/Modal/Modal.stories.mdx
+++ b/src/Modal/Modal.stories.mdx
@@ -16,7 +16,7 @@ Demonstrates default rendering of Modal component.
 
 <Preview>
   <Story name="default">
-    <Modal title="Lorem ipsum dolor sit amet" open={false} onClose={action('onClose')} />
+    <Modal title="Lorem ipsum dolor sit amet" open={false} />
   </Story>
 </Preview>
 
@@ -24,28 +24,7 @@ Demonstrates a Modal with content.
 
 <Preview>
   <Story name="with content">
-    <Modal title="Lorem ipsum dolor sit amet" open={false} onClose={action('onClose')}>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-        labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
-    </Modal>
-  </Story>
-</Preview>
-
-Demonstrates a Modal with Max Width.
-
-<Preview>
-  <Story name="max width">
-    <Modal
-      title="Lorem ipsum dolor sit amet"
-      open={false}
-      onClose={action('onClose')}
-      maxWidth="600px"
-    >
+    <Modal title="Lorem ipsum dolor sit amet" open={false}>
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
         labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
@@ -64,7 +43,6 @@ Demonstrates a Modal with actions.
     <Modal
       title="Are you sure you want to delete?"
       open={false}
-      onClose={action('onClose')}
       actions={[
         <Button key="action-1" onClick={action('Accept')} color="primary" rounded>
           Accept
@@ -169,7 +147,6 @@ Demonstrates a Modal with Backdrop Click.
     <Modal
       title="Lorem ipsum dolor sit amet"
       open={false}
-      onClose={action('onClose')}
       onBackdropClick={action('Backdrop Clicked!')}
     >
       <p>

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -47,7 +47,7 @@ const Dialog = styled.dialog`
   left: 50%;
   transform: translate(-50%, -50%);
   min-width: 30vw;
-  max-width: ${props => props.maxWidth ?? '90vw'};
+  max-width: 90vw;
   max-height: 90vh;
   border: 1px solid #000;
   border-radius: 5px;
@@ -122,7 +122,6 @@ class Modal extends Component {
       actions,
       children,
       className,
-      maxWidth,
       onClose,
       onExited,
       open,
@@ -154,7 +153,6 @@ class Modal extends Component {
           open={open}
           // this is because the Material dialog ONLY fires its native onClose with escape or overlay click, not any time the modal is closed
           scroll="paper"
-          maxWidth={maxWidth}
         >
           {showTitle && (
             <Title
@@ -188,8 +186,6 @@ Modal.propTypes = {
   actions: PropTypes.any,
   children: PropTypes.node,
   className: PropTypes.string,
-  fullScreen: PropTypes.bool,
-  maxWidth: PropTypes.string,
   onClose: PropTypes.func,
   onEntered: PropTypes.func,
   onExited: PropTypes.func,
@@ -205,7 +201,6 @@ Modal.propTypes = {
 }
 
 Modal.defaultProps = {
-  fullScreen: false,
   onClose: () => {},
   theme: defaultTheme,
   showTitle: true,

--- a/src/Modal/index.js
+++ b/src/Modal/index.js
@@ -86,6 +86,12 @@ class Modal extends Component {
   constructor(props) {
     super(props)
     this.titleId = uniqueId('hw-modal-title')
+
+    this.handleClose = this.handleClose.bind(this)
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.open && !this.props.open) this.handleClose()
   }
 
   componentDidMount() {
@@ -105,6 +111,10 @@ class Modal extends Component {
 
     // Click is outside
     open && onBackdropClick && onBackdropClick()
+  }
+
+  handleClose(event) {
+    this.props.onClose(event)
   }
 
   render() {


### PR DESCRIPTION
- Removing maxWidth prop from `Modal`
- Removing unused fullScreen prop from `Modal`
- Fixing onClose event for `Modal`
- Removing onClose stories for `Modal` since they are overidden by ModalStoryWrapper